### PR TITLE
fix: remove unused NeZero d instance in broadcast_eq

### DIFF
--- a/ChandraFurstLipton/NOFModel.lean
+++ b/ChandraFurstLipton/NOFModel.lean
@@ -48,7 +48,7 @@ noncomputable def funComplexity (F : (ZMod d → G) → Bool) := ⨅ P : Protoco
 @[simp] lemma le_funComplexity : t ≤ funComplexity F ↔ ∀ P : Protocol G d, t ≤ P.complexity F := by
   simp [funComplexity]
 
-lemma IsForbiddenPatternWithTip.broadcast_eq [NeZero d] (hF : IsForbiddenPatternWithTip a v)
+lemma IsForbiddenPatternWithTip.broadcast_eq (hF : IsForbiddenPatternWithTip a v)
     (hB : ∀ i, P.broadcast (a i) t = B) : P.broadcast v t = B := by
   induction t generalizing B with
   | zero => simpa using hB 0


### PR DESCRIPTION
## Summary
Remove unused `NeZero d` typeclass instance from `IsForbiddenPatternWithTip.broadcast_eq` lemma.

## Details
The `unusedArguments` linter flagged the `NeZero d` instance as unused. The proof does not require the constraint that `d ≠ 0`, so it can be safely removed.

## Test plan
- ✅ Built `ChandraFurstLipton.NOFModel` successfully
- ✅ Verified `unusedArguments` linter warning is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)